### PR TITLE
fix: optimize Dockerfile.api for local testnet

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -2,21 +2,19 @@ FROM python:3.9.12-slim
 
 WORKDIR /app
 
-# Install dependencies
+# Install dependencies (env vars handle Zscaler SSL bypass without mutating pip config)
 COPY requirements.txt requirements_api.txt ./
-RUN pip3 install --no-cache-dir -r requirements.txt && \
-    pip3 install --no-cache-dir -r requirements_api.txt
+RUN PIP_TRUSTED_HOST="pypi.org files.pythonhosted.org pypi.python.org" \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    pip3 install --no-cache-dir -r requirements.txt -r requirements_api.txt
 
 # Copy application code
 COPY ethstaker_deposit ./ethstaker_deposit
 COPY api ./api
 
-# Create keystores directory with proper permissions
-RUN mkdir -p /app/keystores && \
-    chmod 755 /app/keystores
-
-# Create non-root user
+# Create keystores directory and non-root user
 RUN useradd -m -u 65532 -s /bin/bash app && \
+    mkdir -p /app/keystores && \
     chown -R app:app /app
 
 USER app

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -2,19 +2,18 @@ FROM python:3.9.12-slim
 
 WORKDIR /app
 
-# Install dependencies (env vars handle Zscaler SSL bypass without mutating pip config)
+# Install dependencies
 COPY requirements.txt requirements_api.txt ./
-RUN PIP_TRUSTED_HOST="pypi.org files.pythonhosted.org pypi.python.org" \
-    PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    pip3 install --no-cache-dir -r requirements.txt -r requirements_api.txt
+RUN pip3 install --no-cache-dir -r requirements.txt -r requirements_api.txt
 
 # Copy application code
 COPY ethstaker_deposit ./ethstaker_deposit
 COPY api ./api
 
-# Create keystores directory and non-root user
+# Create non-root user and keystores directory with restrictive permissions
 RUN useradd -m -u 65532 -s /bin/bash app && \
     mkdir -p /app/keystores && \
+    chmod 700 /app/keystores && \
     chown -R app:app /app
 
 USER app


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                             
  - Remove `PIP_TRUSTED_HOST` SSL bypass from Dockerfile — Docker builds don't route through Zscaler, so no bypass is needed at image build time
  - Tighten `/app/keystores` permissions to `700` (owner-only) since it holds sensitive validator key material
  - Combine both `requirements.txt` files into a single `pip install` call (fewer layers, faster builds)
  - Merge `useradd`/`mkdir`/`chmod`/`chown` into one `RUN` layer for smaller image

  ## Test plan
  - [ ] Build: `docker build -f Dockerfile.api -t ethstaker-api .`
  - [ ] Run: `docker run -p 8000:8000 ethstaker-api`
  - [ ] Verify `/provision` endpoint responds
  - [ ] Verify keystores dir is `drwx------` (700): `docker run ethstaker-api ls -la /app/keystores`